### PR TITLE
feat(user): extract common fields from doctors and patients into users

### DIFF
--- a/src/storage/appointments.json
+++ b/src/storage/appointments.json
@@ -1,1 +1,74 @@
-[{"id":"5c3e0f91-47b9-4d72-9f3a-2b9e1a6d0f78","doctorId":"5a105e8b-9d40-4a61-8b12-d9d54e8a64bf","patientId":"01fd6306-7306-4d02-bf4c-df99114d03b9","procedureType":"microsurgery","timeISO":"2025-07-04T08:30:00.000Z","createdAt":"2025-06-15T19:30:00.000Z","updatedAt":"2025-06-15T19:30:00.000Z"},{"id":"a9e76b5f-1d34-4c81-83d9-7f0b6e2c9a45","doctorId":"6f4922f4-6a16-4a3b-9c12-95b5b4a7f1bc","patientId":"4b38c2a2-7335-4d06-8f96-8d4cb5e86cce","procedureType":"facelift","timeISO":"2025-06-15T19:30:00.000Z","createdAt":"2025-06-15T19:30:00.000Z","updatedAt":"2025-06-15T19:30:00.000Z"},{"id":"8b6d3c2a-5f19-49e7-8a2d-4c5e7b9f1230","doctorId":"7c5aba41-60ef-43a8-9a1c-32811e14a7b0","patientId":"7901fbd5-23ff-47aa-9251-7f54b73ff92b","procedureType":"scar revision","timeISO":"2025-08-15T18:30:00.000Z","createdAt":"2025-06-15T19:30:00.000Z","updatedAt":"2025-06-15T19:30:00.000Z"},{"id":"3e5a9f18-4b62-47c0-9b1e-6f2d3a7e8b49","doctorId":"9bf31c7f-28d6-4d27-b8ae-4d1211e3e847","patientId":"4d734b14-547d-476b-a44f-54de69b202a0","procedureType":"liposuction","timeISO":"2025-06-25T19:30:00.000Z","createdAt":"2025-06-15T19:30:00.000Z","updatedAt":"2025-06-15T19:30:00.000Z"},{"id":"f7d8a4b2-61c3-4e90-97f2-0b3d1a9e4f56","doctorId":"c9f0f895-7e61-4e94-bb26-cff59d12a401","patientId":"d738ddf5-0603-4ad7-8056-c1de1c9311c5","procedureType":"reconstructive nose surgery","timeISO":"2025-06-15T14:30:00.000Z","createdAt":"2025-06-15T19:30:00.000Z","updatedAt":"2025-06-15T19:30:00.000Z"},{"id":"2a9f3d5e-7c84-4b1a-83e7-9d0f6c2b4e71","doctorId":"187a1a16-ba58-4159-94aa-8b0084c685c8","patientId":"02d574b4-cdad-4f1a-9c0c-d348deba6c6c","procedureType":"scar revision","timeISO":"2025-08-15T16:30:00.000Z","createdAt":"2025-06-15T19:30:00.000Z","updatedAt":"2025-06-15T19:30:00.000Z"},{"id":"1034d541-aece-4972-8386-d5280eab4aa4","doctorId":"8f14e45f-ea6b-4b8e-9d03-2f64c6d3cbb1","patientId":"c7c4cbaa-e34a-4e78-9a75-b42099c3bc30","timeISO":"2025-08-31T10:15:00Z","procedureType":"rhinoplasty","createdAt":"2025-07-23T19:15:54.701Z","updatedAt":"2025-07-23T19:15:54.701Z"},{"id":"d5e38c7d-fbfe-4870-9113-70376800c18d","doctorId":"8f14e45f-ea6b-4b8e-9d03-2f64c6d3cbb1","patientId":"c7c4cbaa-e34a-4e78-9a75-b42099c3bc30","timeISO":"2025-10-31T13:15:00Z","procedureType":"rhinoplasty","createdAt":"2025-08-15T07:21:56.237Z","updatedAt":"2025-08-15T07:21:56.237Z"}]
+[
+  {
+    "id": "5c3e0f91-47b9-4d72-9f3a-2b9e1a6d0f78",
+    "doctorId": "5a105e8b-9d40-4a61-8b12-d9d54e8a64bf",
+    "patientId": "01fd6306-7306-4d02-bf4c-df99114d03b9",
+    "procedureType": "microsurgery",
+    "timeISO": "2025-07-04T08:30:00.000Z",
+    "createdAt": "2025-06-15T19:30:00.000Z",
+    "updatedAt": "2025-06-15T19:30:00.000Z"
+  },
+  {
+    "id": "a9e76b5f-1d34-4c81-83d9-7f0b6e2c9a45",
+    "doctorId": "6f4922f4-6a16-4a3b-9c12-95b5b4a7f1bc",
+    "patientId": "4b38c2a2-7335-4d06-8f96-8d4cb5e86cce",
+    "procedureType": "facelift",
+    "timeISO": "2025-06-15T19:30:00.000Z",
+    "createdAt": "2025-06-15T19:30:00.000Z",
+    "updatedAt": "2025-06-15T19:30:00.000Z"
+  },
+  {
+    "id": "8b6d3c2a-5f19-49e7-8a2d-4c5e7b9f1230",
+    "doctorId": "7c5aba41-60ef-43a8-9a1c-32811e14a7b0",
+    "patientId": "7901fbd5-23ff-47aa-9251-7f54b73ff92b",
+    "procedureType": "scar revision",
+    "timeISO": "2025-08-15T18:30:00.000Z",
+    "createdAt": "2025-06-15T19:30:00.000Z",
+    "updatedAt": "2025-06-15T19:30:00.000Z"
+  },
+  {
+    "id": "3e5a9f18-4b62-47c0-9b1e-6f2d3a7e8b49",
+    "doctorId": "9bf31c7f-28d6-4d27-b8ae-4d1211e3e847",
+    "patientId": "4d734b14-547d-476b-a44f-54de69b202a0",
+    "procedureType": "liposuction",
+    "timeISO": "2025-06-25T19:30:00.000Z",
+    "createdAt": "2025-06-15T19:30:00.000Z",
+    "updatedAt": "2025-06-15T19:30:00.000Z"
+  },
+  {
+    "id": "f7d8a4b2-61c3-4e90-97f2-0b3d1a9e4f56",
+    "doctorId": "c9f0f895-7e61-4e94-bb26-cff59d12a401",
+    "patientId": "d738ddf5-0603-4ad7-8056-c1de1c9311c5",
+    "procedureType": "reconstructive nose surgery",
+    "timeISO": "2025-06-15T14:30:00.000Z",
+    "createdAt": "2025-06-15T19:30:00.000Z",
+    "updatedAt": "2025-06-15T19:30:00.000Z"
+  },
+  {
+    "id": "2a9f3d5e-7c84-4b1a-83e7-9d0f6c2b4e71",
+    "doctorId": "187a1a16-ba58-4159-94aa-8b0084c685c8",
+    "patientId": "02d574b4-cdad-4f1a-9c0c-d348deba6c6c",
+    "procedureType": "scar revision",
+    "timeISO": "2025-08-15T16:30:00.000Z",
+    "createdAt": "2025-06-15T19:30:00.000Z",
+    "updatedAt": "2025-06-15T19:30:00.000Z"
+  },
+  {
+    "id": "1034d541-aece-4972-8386-d5280eab4aa4",
+    "doctorId": "8f14e45f-ea6b-4b8e-9d03-2f64c6d3cbb1",
+    "patientId": "c7c4cbaa-e34a-4e78-9a75-b42099c3bc30",
+    "timeISO": "2025-08-31T10:15:00Z",
+    "procedureType": "rhinoplasty",
+    "createdAt": "2025-07-23T19:15:54.701Z",
+    "updatedAt": "2025-07-23T19:15:54.701Z"
+  },
+  {
+    "id": "d5e38c7d-fbfe-4870-9113-70376800c18d",
+    "doctorId": "8f14e45f-ea6b-4b8e-9d03-2f64c6d3cbb1",
+    "patientId": "c7c4cbaa-e34a-4e78-9a75-b42099c3bc30",
+    "timeISO": "2025-10-31T13:15:00Z",
+    "procedureType": "rhinoplasty",
+    "createdAt": "2025-08-15T07:21:56.237Z",
+    "updatedAt": "2025-08-15T07:21:56.237Z"
+  }
+]

--- a/src/storage/doctors.json
+++ b/src/storage/doctors.json
@@ -1,8 +1,6 @@
 [
   {
-    "id": "5a105e8b-9d40-4a61-8b12-d9d54e8a64bf",
-    "firstName": "Domenico",
-    "lastName": "Laezza",
+    "userId": "5a105e8b-9d40-4a61-8b12-d9d54e8a64bf",
     "specialization": "plastic surgeon",
     "schedule": [
       {
@@ -50,14 +48,10 @@
         "start": "08:00:00",
         "end": "14:00:00"
       }
-    ],
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
+    ]
   },
   {
-    "id": "6f4922f4-6a16-4a3b-9c12-95b5b4a7f1bc",
-    "firstName": "Carmine",
-    "lastName": "Gallo",
+    "userId": "6f4922f4-6a16-4a3b-9c12-95b5b4a7f1bc",
     "specialization": "cosmetologist",
     "schedule": [
       {
@@ -105,14 +99,10 @@
         "start": "08:00:00",
         "end": "14:00:00"
       }
-    ],
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
+    ]
   },
   {
-    "id": "7c5aba41-60ef-43a8-9a1c-32811e14a7b0",
-    "firstName": "Francesco",
-    "lastName": "Core",
+    "userId": "7c5aba41-60ef-43a8-9a1c-32811e14a7b0",
     "specialization": "dermatologist",
     "schedule": [
       {
@@ -156,14 +146,10 @@
         "day": "Sunday",
         "isAvailable": false
       }
-    ],
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
+    ]
   },
   {
-    "id": "9bf31c7f-28d6-4d27-b8ae-4d1211e3e847",
-    "firstName": "Luigi",
-    "lastName": "Gallo",
+    "userId": "9bf31c7f-28d6-4d27-b8ae-4d1211e3e847",
     "specialization": "breast surgeon",
     "schedule": [
       {
@@ -209,14 +195,11 @@
         "day": "Sunday",
         "isAvailable": false
       }
-    ],
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
+    ]
   },
   {
     "id": "c9f0f895-7e61-4e94-bb26-cff59d12a401",
-    "firstName": "Antonio",
-    "lastName": "Morelli",
+    "userId": "e1e66c8f-ec15-401c-9b8b-fdd654e87567",
     "specialization": "intimate surgeon",
     "schedule": [
       {
@@ -262,53 +245,18 @@
         "start": "08:00:00",
         "end": "14:00:00"
       }
-    ],
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
+    ]
   },
   {
     "id": "187a1a16-ba58-4159-94aa-8b0084c685c8",
-    "firstName": "Armando",
-    "lastName": "Laezza",
+    "userId": "b8a189c3-a3a2-40b5-bc5a-df99a02ba065",
     "specialization": "oculoplastic surgeon",
-    "schedule": [],
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
+    "schedule": []
   },
   {
     "id": "d549b181-ed9d-422b-b43d-5e44cb592af8",
-    "firstName": "Amerigo",
-    "lastName": "Vespuci",
+    "userId": "d068bf3a-b931-4d28-83ec-b1d9e25afb4a",
     "specialization": "ear surgeon",
-    "schedule": [],
-    "createdAt": "2025-07-02T19:48:15.278Z",
-    "updatedAt": "2025-07-02T19:48:15.280Z"
-  },
-  {
-    "id": "e9452837-d283-45b6-8242-f771680ee34b",
-    "firstName": "Amerigo",
-    "lastName": "Core",
-    "specialization": "rhinoplasty",
-    "schedule": [],
-    "createdAt": "2025-07-02T19:50:22.823Z",
-    "updatedAt": "2025-07-02T19:50:22.823Z"
-  },
-  {
-    "id": "4d785407-36fb-4f56-aac4-7e930150b90f",
-    "firstName": "Paul",
-    "lastName": "Core",
-    "specialization": "rhinoplasty",
-    "schedule": [],
-    "createdAt": "2025-07-07T19:59:29.103Z",
-    "updatedAt": "2025-07-07T19:59:29.104Z"
-  },
-  {
-    "id": "763b7fbf-1ce4-46a8-ad49-544e3600c44a",
-    "firstName": "Maria",
-    "lastName": "Rosaria",
-    "specialization": "facelift",
-    "schedule": [],
-    "createdAt": "2025-08-02T10:42:46.719Z",
-    "updatedAt": "2025-08-02T10:42:46.719Z"
+    "schedule": []
   }
 ]

--- a/src/storage/patients.json
+++ b/src/storage/patients.json
@@ -1,90 +1,28 @@
 [
   {
+    "id": "e9452837-d283-45b6-8242-f771680ee34b",
+    "userId": "d8d18d3b-475d-4aa8-9815-c8ae90840395",
+    "phone": "+399458845221"
+  },
+  {
+    "id": "4d785407-36fb-4f56-aac4-7e930150b90f",
+    "userId": "d767d553-49a9-42fd-b9f6-a6e874afd8b0",
+    "phone": "+393595519872"
+  },
+  {
+    "id": "763b7fbf-1ce4-46a8-ad49-544e3600c44a",
+    "userId": "ab61ab9b-2c59-41a2-b405-3fd93cd478bf",
+    "phone": "+397787748992"
+  },
+  {
     "id": "01fd6306-7306-4d02-bf4c-df99114d03b9",
-    "firstName": "Marco",
-    "lastName": "Bianchi",
-    "phone": "+397777777777",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-08-02T18:02:16.987Z"
+    "userId": "e2e34cd8-88c3-47e4-8e90-19471ec8ec7c",
+    "phone": "+395526998440"
   },
   {
     "id": "4b38c2a2-7335-4d06-8f96-8d4cb5e86cce",
-    "firstName": "Giulia",
-    "lastName": "Romano",
-    "phone": "+393473334455",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "7901fbd5-23ff-47aa-9251-7f54b73ff92b",
-    "firstName": "Leonardo",
-    "lastName": "Gallo",
-    "phone": "+393474445566",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "2e378275-4977-4668-8988-7d4ec6f08b2e",
-    "firstName": "Sofia",
-    "lastName": "Conti",
-    "phone": "+393475556677",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "4d734b14-547d-476b-a44f-54de69b202a0",
-    "firstName": "Mattia",
-    "lastName": "Ricci",
-    "phone": "+393476667788",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "d738ddf5-0603-4ad7-8056-c1de1c9311c5",
-    "firstName": "Chiara",
-    "lastName": "Greco",
-    "phone": "+393477778899",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "02d574b4-cdad-4f1a-9c0c-d348deba6c6c",
-    "firstName": "Andrea",
-    "lastName": "Fontana",
-    "phone": "+393478889900",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "c175812d-efb8-4e76-b328-0f9be54b04a7",
-    "firstName": "Elena",
-    "lastName": "De Luca",
-    "phone": "+393479990011",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "4f19c594-bc89-4b5a-85e9-9e7d2b6d1a7b",
-    "firstName": "Nicolo",
-    "lastName": "Marino",
-    "phone": "+393480101112",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "f0a53f02-bb2c-456c-84b1-fcd16b21f3e1",
-    "firstName": "Martina",
-    "lastName": "Vitale",
-    "phone": "+393481212223",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
-  },
-  {
-    "id": "8e90e7f4-ecf5-4d64-a00e-6a9c4b9e20de",
-    "firstName": "Riccardo",
-    "lastName": "Lombardi",
-    "phone": "+393482323334",
-    "createdAt": "2025-06-15T19:30:00.000Z",
-    "updatedAt": "2025-06-15T19:30:00.000Z"
+    "userId": "61b13af4-05c1-4788-b607-443c71ffe597",
+    "phone": "+397885523663"
   }
+
 ]

--- a/src/storage/users.json
+++ b/src/storage/users.json
@@ -4,7 +4,7 @@
     "firstName": "Savino",
     "lastName": "Laezza",
     "email": "s.laezza@gmail.com",
-    "password": "$2b$10$Ku5dijTvIki28/R70DCsROzokFO.sm6muv7nHO1z8MXqiRJ3uIghG",
+    "password": "$2b$10$LPplXtp6ImQGnpFsORtFJuuyK7tNL0lghhUdui7nKEoYtEyGrS10u",
     "createdAt": "2025-06-15T19:30:00.000Z",
     "updatedAt": "2025-08-15T07:31:49.195Z",
     "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVhMTA1ZThiLTlkNDAtNGE2MS04YjEyLWQ5ZDU0ZThhNjRiZiIsImlhdCI6MTc1NTQzNDczMCwiZXhwIjoxNzU4MDI2NzMwfQ.28lS7zpRTt1Jv_SWnHqjCPjEiqpNuKuFYBLMvmarNPA"
@@ -37,13 +37,13 @@
     "updatedAt": "2025-06-15T19:30:00.000Z"
   },
   {
-    "_id": "e1e66c8f-ec15-401c-9b8b-fdd654e87567",
-    "_firstName": "Robin",
-    "_lastName": "Kennedy",
-    "_email": "r.kennedy@gmail.com",
-    "_password": "12345678",
-    "_createdAt": "2025-08-09T16:57:30.378Z",
-    "_updatedAt": "2025-08-09T16:57:30.378Z"
+    "id": "e1e66c8f-ec15-401c-9b8b-fdd654e87567",
+    "firstName": "Robin",
+    "lastName": "Kennedy",
+    "email": "r.kennedy@gmail.com",
+    "password": "12345678",
+    "createdAt": "2025-08-09T16:57:30.378Z",
+    "updatedAt": "2025-08-09T16:57:30.378Z"
   },
   {
     "id": "b8a189c3-a3a2-40b5-bc5a-df99a02ba065",


### PR DESCRIPTION
# Description of Changes  

## What has been done  
- Moved common fields (`firstName`, `lastName`, `createdAt`, `updatedAt`) from **doctors.json** and **patients.json** into **users.json**.  
- Added `userId` references in **doctor** and **patient** entities.  
- Updated all three JSON files to follow the new structure.  

## Why it was done  
- To eliminate data duplication across entities.  
- To prepare for future role-based functionality and cleaner architecture.  

## How to test  
1. Open `users.json`, `doctors.json`, and `patients.json`.  
2. Verify that doctor and patient entities now contain `userId` and common fields are only stored in `users.json`.  
3. Ensure that all references are consistent and no links are broken.  

## Related issues  
—  

## Implementation details  
- Passwords are stored only in `users.json`.  
- Existing `id`s were preserved to maintain data consistency.  

## Limitations and known issues  
- This change only affects JSON data structure, no API endpoints or logic have been updated yet.  
