### PR TITLE
feat(doctors): invites for doctor registration (need to fix: registration by token)

### DIFF
--- a/src/auth/auth-controller.ts
+++ b/src/auth/auth-controller.ts
@@ -13,12 +13,26 @@ import {
 
 export const register = async (req: Request<{}, unknown, FullRegisterInfo>, res: Response<{message: string}>): Promise<void> => {
     const tokens = await Service.register(req);
+
+    if(tokens == null) {res.status(201).send({message: "Your request for registration was created. Wait for email."})
+    } else {
+        res.cookie('refreshToken', tokens.refreshToken, {
+            secure: true,
+            httpOnly: true,
+            maxAge: 30 * 24 * 60 * 60 * 1000
+        })
+        res.status(201).send({message: "New user was registered successfully"})
+    }
+}
+
+export const registerByToken = async (req: Request<{token: string}, unknown, FullRegisterInfo>, res: Response<{message: string}>): Promise<void> => {
+    const tokens = await Service.registerByToken(req);
     res.cookie('refreshToken', tokens.refreshToken, {
         secure: true,
         httpOnly: true,
         maxAge: 30 * 24 * 60 * 60 * 1000
     })
-    res.status(201).send({message: "New user was registered successfully"})
+    res.status(201).send({message: "New user was registered successfully with using invite token"})
 }
 
 export const login = async (req: Request<{}, unknown, Credentials>, res: Response<AuthTokens>): Promise<void> => {

--- a/src/auth/auth-router.ts
+++ b/src/auth/auth-router.ts
@@ -1,10 +1,19 @@
 import express, {Router} from "express";
-import {changePassword, login, logout, register, requestResetPassword, resetPassword} from "./auth-controller.js";
+import {
+    changePassword,
+    login,
+    logout,
+    register,
+    registerByToken,
+    requestResetPassword,
+    resetPassword
+} from "./auth-controller.js";
 import {authenticate} from "../shared/middleware/authenticate.js";
 
 const router: Router = express.Router();
 
 router.post('/register', register)
+router.post('/register/:token', registerByToken)
 router.post('/login', login)
 router.post('/logout', authenticate, logout)
 router.post('/request-reset-password', requestResetPassword)

--- a/src/doctors/doctors-controller.ts
+++ b/src/doctors/doctors-controller.ts
@@ -1,5 +1,5 @@
 import {Request, Response} from "express";
-import {UpdateDoctorBody} from "./types.js";
+import {DoctorInviteToken, UpdateDoctorBody} from "./types.js";
 import {Service} from "./service.js";
 import {AllInfoUser} from "../users/types.js";
 import {Appointment} from "../appointments/types.js";
@@ -28,5 +28,10 @@ export const remove = async (req: Request, res: Response<void>): Promise<void> =
 export const getAppointments = async (req: Request, res: Response<Appointment[]>): Promise<void> => {
     const appointments = await Service.getAppointments(req)
     res.status(200).send(appointments)
+}
+
+export const inviteDoctor = async (req: Request, res: Response<DoctorInviteToken>): Promise<void> => {
+    await Service.sendInviteDoctor(req)
+    res.status(200).send()
 }
 

--- a/src/doctors/doctors-router.ts
+++ b/src/doctors/doctors-router.ts
@@ -1,5 +1,5 @@
 import express, {Router} from 'express';
-import {getAll, getAppointments, getById, remove, update} from "./doctors-controller.js";
+import {getAll, getAppointments, getById, inviteDoctor, remove, update} from "./doctors-controller.js";
 import {validateRequest} from "../shared/middleware/validate-request.js";
 import {doctorIdSchema, searchDoctorSchema, updateDoctorSchema} from "./validation.js";
 import {authorize} from "../shared/middleware/authorize.js";
@@ -63,6 +63,10 @@ router.get('/me/appointments',
     getAppointments
 )
 
-
+router.post('/invite',
+    authenticate,
+    authorize([Role.ADMIN]),
+    inviteDoctor
+)
 
 export default router;

--- a/src/doctors/service.ts
+++ b/src/doctors/service.ts
@@ -9,6 +9,8 @@ import {AllInfoUser} from "../users/types.js";
 import {ServiceHelper as AppointmentServiceHelper} from "../appointments/service.js"
 import {Appointment} from "../appointments/types.js";
 import {id} from "../shared/validation/joi-common.js";
+import jwt from "jsonwebtoken";
+import nodemailer from "nodemailer";
 
 export class Service {
     // DONE
@@ -55,6 +57,52 @@ export class Service {
     static async getAppointments(req: Request): Promise<Appointment[] | undefined> {
         const loggedUser = req.user!;
         return await AppointmentServiceHelper.getAppointmentsData({doctorId: loggedUser.id})
+    }
+
+    static async sendInviteDoctor(req: Request): Promise<string> {
+        const email = req.body.email;
+
+        const secret: string = process.env.RESET_PASSWORD_JWT as string
+
+        const token = jwt.sign({email}, secret, {expiresIn: '15m'})
+        const registrationLink = `${process.env.API_URL}:${process.env.PORT}/auth/register/${token}`
+
+        const transporter = nodemailer.createTransport({
+            host: "smtp.gmail.com",
+            port: 465,
+            secure: true,
+            auth: {
+                user: `${process.env.MAIL_USER}`,
+                pass: `${process.env.MAIL_PASS}`
+            },
+            tls: {
+                rejectUnauthorized: false,
+            },
+        });
+
+        const mailOptions = {
+            to: email,
+            from: process.env.MAIL_USER,
+            subject: 'Invite Link',
+            text: `You are receiving this email because you have been invited to join our medical platform as a doctor.
+            Please click on the following link, or paste it into your browser, to complete your registration and set up your account:\n\n
+          ${registrationLink}\n\n
+          If you did not request this registration, please contact our support team at: +33 333 333 33 33.\n`,
+        }
+
+        console.log(mailOptions)
+
+        // for tests:
+        // make definition of info asynchronous (add await)
+        const info = await transporter.sendMail(mailOptions)
+
+
+
+        // for tests:
+        // uncomment the line below
+        console.log("Preview URL:", nodemailer.getTestMessageUrl(info));
+
+        return token
     }
 }
 

--- a/src/doctors/types.d.ts
+++ b/src/doctors/types.d.ts
@@ -31,4 +31,7 @@ export interface DoctorsParams {
     id: string;
 }
 
+export interface DoctorInviteToken {
+    inviteToken: string;
+}
 

--- a/src/shared/middleware/authenticate.ts
+++ b/src/shared/middleware/authenticate.ts
@@ -14,7 +14,7 @@ export const authenticate = (req: Request, res: Response, next: NextFunction) =>
         if (err) { // @ts-ignore
             return res.sendStatus(403)
         }
-
+        // @ts-ignore
         req.user = decoded as {id: string, role: string};
         next();
     })

--- a/src/shared/middleware/authorize.ts
+++ b/src/shared/middleware/authorize.ts
@@ -1,10 +1,11 @@
 import {Request, Response, NextFunction, RequestHandler} from "express";
 import {Role} from "../roles.js";
 
-export const authorize = (roles: Role[]): RequestHandler => {
+
+export const authorize = (roles: Role[]) => {
     return (req: Request, res: Response, next: NextFunction) => {
-        const user = req.user;
-        if(!user || !roles.includes(user.role as Role)) {
+        const user = req.user!;
+        if(!user.role || !roles.includes(user.role as Role)) {
             return res.status(401).send({
                 message: "Access denied. Your account does not have the required permissions."
             })

--- a/src/storage/auth.json
+++ b/src/storage/auth.json
@@ -1,1 +1,83 @@
-[{"userId":"63545c5b-e1ea-4800-9390-c12abb32925c","email":"b.obama@gmail.com","password":"$2b$10$LPplXtp6ImQGnpFsORtFJuuyK7tNL0lghhUdui7nKEoYtEyGrS10u","refreshToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNTQ1YzViLWUxZWEtNDgwMC05MzkwLWMxMmFiYjMyOTI1YyIsInJvbGUiOiJhZG1pbiIsImlhdCI6MTc1ODk1OTI0MSwiZXhwIjoxNzYxNTUxMjQxfQ.rXJYB3dZFHs4ws3SqnZidvxbS_fQJDDZn5-72JhH4kg"},{"userId":"7c5aba41-60ef-43a8-9a1c-32811e14a7b0","email":"f.core@gmail.com","password":"$2b$10$lXqbNNLg/rsjQQiOBcU8heVJUAV1C1SHHVuf7tdQbuNaBmEomEHLi","refreshToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjdjNWFiYTQxLTYwZWYtNDNhOC05YTFjLTMyODExZTE0YTdiMCIsInJvbGUiOiJkb2N0b3IiLCJpYXQiOjE3NTg5NTU5NzYsImV4cCI6MTc2MTU0Nzk3Nn0.unisbrruRN8jdSRJHkv79h5FiAOtRhZGfxHTb5W1v2U"},{"userId":"9bf31c7f-28d6-4d27-b8ae-4d1211e3e847","email":"l.Gallo@gmail.com","password":"$2b$10$lXqbNNLg/rsjQQiOBcU8heVJUAV1C1SHHVuf7tdQbuNaBmEomEHLi"},{"userId":"e1e66c8f-ec15-401c-9b8b-fdd654e87567","email":"r.kennedy@gmail.com","password":"12345678"},{"userId":"b8a189c3-a3a2-40b5-bc5a-df99a02ba065","email":"r.kennedy@gmail.com","password":"12345678"},{"userId":"d068bf3a-b931-4d28-83ec-b1d9e25afb4a","email":"a.macrony@gmail.com","password":"12345678"},{"userId":"d8d18d3b-475d-4aa8-9815-c8ae90840395","email":"d.morano@gmail.com","password":"$2b$10$t3YI.UljGUtBWxN0Eb9KIOC3bfCGKwQ7xFa7/dqPVS5peSuI7qKHy"},{"userId":"d767d553-49a9-42fd-b9f6-a6e874afd8b0","email":"v.armani@gmail.com","password":"$2b$10$ZfL8zeqsa5pDb83KN483y.jt0dNwFK2KKyNqDHhcUmmaqdw7g.2iC","refreshToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJkNzY3ZDU1My00OWE5LTQyZmQtYjlmNi1hNmU4NzRhZmQ4YjAiLCJyb2xlIjoicGF0aWVudCIsImlhdCI6MTc1ODY1NzUwMCwiZXhwIjoxNzYxMjQ5NTAwfQ.bocRANJA3Avyr7LJNEMAuzcQrKAK4f2ltIbrHWgbsTY"},{"userId":"ab61ab9b-2c59-41a2-b405-3fd93cd478bf","email":"g.pesca@gmail.com","password":"$2b$10$p7zKuiCAGy4yIHc3wopbJ.qwH3o6ttfr78JOBiBvoE1k76WpmVqoO"},{"userId":"e2e34cd8-88c3-47e4-8e90-19471ec8ec7c","email":"a.debole@gmail.com","password":"$2b$10$lyzcxpHJrCkvKf3DC8MtiuKFJPn0kt71RpVAXmInPL2d9noa2YMXu"},{"userId":"61b13af4-05c1-4788-b607-443c71ffe597","email":"r.blue@gmail.com","password":"$2b$10$OIYKrNiFDfvI1tZ22n433eHuNV563wjilYkDw0pYK3pnvIHvgH3gC","refreshToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYxYjEzYWY0LTA1YzEtNDc4OC1iNjA3LTQ0M2M3MWZmZTU5NyIsInJvbGUiOiJwYXRpZW50IiwiaWF0IjoxNzU4NzQwMjI2LCJleHAiOjE3NjEzMzIyMjZ9.Y46rNwdrQlfj7FclWB6oDPU6O7zg6Zo4y7OhOtFjhMo"},{"userId":"0b90e4f9-f4a9-4279-9a4a-8387589789bb","email":"r.mirkop@gmail.com","password":"$2b$10$BTuT2jjg4mQMPOjfkHyowu.pMCC24DkIQfT24K1OOmKC3h.Xz4VYO","refreshToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjBiOTBlNGY5LWY0YTktNDI3OS05YTRhLTgzODc1ODk3ODliYiIsInJvbGUiOiJwYXRpZW50IiwiaWF0IjoxNzU4ODg2MTkxLCJleHAiOjE3NjE0NzgxOTF9.Ybi34YWCsgkkTLipvTfPgUMdwutvR1xLKNHRkLNFTwM"},{"userId":"2c50667e-d22f-4ee0-9f8a-aaad566c1e55","email":"w.disney@gmail.com","password":"$2b$10$2ZVQ/jFw2P933IFyc3ES.eU6wvc0Q4QeklVI/Qe/i0MuePnBfvCqO"},{"userId":"e78259b1-4cd0-4486-acc1-084c139879b8","email":"w.white@gmail.com","password":"$2b$10$30zAE3TgJTiU7nyHImjaWOAJwfXZfb/QapmG0RfZMGGCXUK20meK.","refreshToken":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImU3ODI1OWIxLTRjZDAtNDQ4Ni1hY2MxLTA4NGMxMzk4NzliOCIsInJvbGUiOiJwYXRpZW50IiwiaWF0IjoxNzU4OTU2NTY5LCJleHAiOjE3NjE1NDg1Njl9.cT-w8gxpi1yhNN7n_aFUTU_XAQOHcd9qLCBtQP9DXY0"}]
+[
+  {
+    "userId": "63545c5b-e1ea-4800-9390-c12abb32925c",
+    "email": "b.obama@gmail.com",
+    "password": "$2b$10$LPplXtp6ImQGnpFsORtFJuuyK7tNL0lghhUdui7nKEoYtEyGrS10u",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNTQ1YzViLWUxZWEtNDgwMC05MzkwLWMxMmFiYjMyOTI1YyIsInJvbGUiOiJhZG1pbiIsImlhdCI6MTc1ODk5OTEzNiwiZXhwIjoxNzYxNTkxMTM2fQ.XIDLz08GsKhW2tXarfQcgtW16C-PVcr9NBHwYMN2Vmo"
+  },
+  {
+    "userId": "7c5aba41-60ef-43a8-9a1c-32811e14a7b0",
+    "email": "f.core@gmail.com",
+    "password": "$2b$10$lXqbNNLg/rsjQQiOBcU8heVJUAV1C1SHHVuf7tdQbuNaBmEomEHLi",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjdjNWFiYTQxLTYwZWYtNDNhOC05YTFjLTMyODExZTE0YTdiMCIsInJvbGUiOiJkb2N0b3IiLCJpYXQiOjE3NTg5NTU5NzYsImV4cCI6MTc2MTU0Nzk3Nn0.unisbrruRN8jdSRJHkv79h5FiAOtRhZGfxHTb5W1v2U"
+  },
+  {
+    "userId": "9bf31c7f-28d6-4d27-b8ae-4d1211e3e847",
+    "email": "l.Gallo@gmail.com",
+    "password": "$2b$10$lXqbNNLg/rsjQQiOBcU8heVJUAV1C1SHHVuf7tdQbuNaBmEomEHLi"
+  },
+  {
+    "userId": "e1e66c8f-ec15-401c-9b8b-fdd654e87567",
+    "email": "r.kennedy@gmail.com",
+    "password": "12345678"
+  },
+  {
+    "userId": "b8a189c3-a3a2-40b5-bc5a-df99a02ba065",
+    "email": "r.kennedy@gmail.com",
+    "password": "12345678"
+  },
+  {
+    "userId": "d068bf3a-b931-4d28-83ec-b1d9e25afb4a",
+    "email": "a.macrony@gmail.com",
+    "password": "12345678"
+  },
+  {
+    "userId": "d8d18d3b-475d-4aa8-9815-c8ae90840395",
+    "email": "d.morano@gmail.com",
+    "password": "$2b$10$t3YI.UljGUtBWxN0Eb9KIOC3bfCGKwQ7xFa7/dqPVS5peSuI7qKHy"
+  },
+  {
+    "userId": "d767d553-49a9-42fd-b9f6-a6e874afd8b0",
+    "email": "v.armani@gmail.com",
+    "password": "$2b$10$ZfL8zeqsa5pDb83KN483y.jt0dNwFK2KKyNqDHhcUmmaqdw7g.2iC",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJkNzY3ZDU1My00OWE5LTQyZmQtYjlmNi1hNmU4NzRhZmQ4YjAiLCJyb2xlIjoicGF0aWVudCIsImlhdCI6MTc1ODY1NzUwMCwiZXhwIjoxNzYxMjQ5NTAwfQ.bocRANJA3Avyr7LJNEMAuzcQrKAK4f2ltIbrHWgbsTY"
+  },
+  {
+    "userId": "ab61ab9b-2c59-41a2-b405-3fd93cd478bf",
+    "email": "g.pesca@gmail.com",
+    "password": "$2b$10$p7zKuiCAGy4yIHc3wopbJ.qwH3o6ttfr78JOBiBvoE1k76WpmVqoO"
+  },
+  {
+    "userId": "e2e34cd8-88c3-47e4-8e90-19471ec8ec7c",
+    "email": "a.debole@gmail.com",
+    "password": "$2b$10$lyzcxpHJrCkvKf3DC8MtiuKFJPn0kt71RpVAXmInPL2d9noa2YMXu"
+  },
+  {
+    "userId": "61b13af4-05c1-4788-b607-443c71ffe597",
+    "email": "r.blue@gmail.com",
+    "password": "$2b$10$OIYKrNiFDfvI1tZ22n433eHuNV563wjilYkDw0pYK3pnvIHvgH3gC",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYxYjEzYWY0LTA1YzEtNDc4OC1iNjA3LTQ0M2M3MWZmZTU5NyIsInJvbGUiOiJwYXRpZW50IiwiaWF0IjoxNzU4NzQwMjI2LCJleHAiOjE3NjEzMzIyMjZ9.Y46rNwdrQlfj7FclWB6oDPU6O7zg6Zo4y7OhOtFjhMo"
+  },
+  {
+    "userId": "0b90e4f9-f4a9-4279-9a4a-8387589789bb",
+    "email": "r.mirkop@gmail.com",
+    "password": "$2b$10$BTuT2jjg4mQMPOjfkHyowu.pMCC24DkIQfT24K1OOmKC3h.Xz4VYO",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjBiOTBlNGY5LWY0YTktNDI3OS05YTRhLTgzODc1ODk3ODliYiIsInJvbGUiOiJwYXRpZW50IiwiaWF0IjoxNzU4ODg2MTkxLCJleHAiOjE3NjE0NzgxOTF9.Ybi34YWCsgkkTLipvTfPgUMdwutvR1xLKNHRkLNFTwM"
+  },
+  {
+    "userId": "2c50667e-d22f-4ee0-9f8a-aaad566c1e55",
+    "email": "w.disney@gmail.com",
+    "password": "$2b$10$2ZVQ/jFw2P933IFyc3ES.eU6wvc0Q4QeklVI/Qe/i0MuePnBfvCqO"
+  },
+  {
+    "userId": "e78259b1-4cd0-4486-acc1-084c139879b8",
+    "email": "w.white@gmail.com",
+    "password": "$2b$10$30zAE3TgJTiU7nyHImjaWOAJwfXZfb/QapmG0RfZMGGCXUK20meK.",
+    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImU3ODI1OWIxLTRjZDAtNDQ4Ni1hY2MxLTA4NGMxMzk4NzliOCIsInJvbGUiOiJwYXRpZW50IiwiaWF0IjoxNzU4OTU2NTY5LCJleHAiOjE3NjE1NDg1Njl9.cT-w8gxpi1yhNN7n_aFUTU_XAQOHcd9qLCBtQP9DXY0"
+  },
+  {
+    "userId": "9c95ddce-f9de-4d24-87c5-a31d3d6d2a0f",
+    "email": "a.criscolo@gmail.com",
+    "password": "$2b$10$Touryzr2zBOqpzP02r1w5uTo57eq6OMIo3hJnJI6xeRlrDr5F6Bxi"
+  }
+]

--- a/src/storage/doctors.json
+++ b/src/storage/doctors.json
@@ -96,7 +96,6 @@
     ]
   },
   {
-    "id": "c9f0f895-7e61-4e94-bb26-cff59d12a401",
     "userId": "e1e66c8f-ec15-401c-9b8b-fdd654e87567",
     "specialization": "intimate surgeon",
     "schedule": [
@@ -146,13 +145,11 @@
     ]
   },
   {
-    "id": "187a1a16-ba58-4159-94aa-8b0084c685c8",
     "userId": "b8a189c3-a3a2-40b5-bc5a-df99a02ba065",
     "specialization": "oculoplastic surgeon",
     "schedule": []
   },
   {
-    "id": "d549b181-ed9d-422b-b43d-5e44cb592af8",
     "userId": "d068bf3a-b931-4d28-83ec-b1d9e25afb4a",
     "specialization": "ear surgeon",
     "schedule": []

--- a/src/storage/users.json
+++ b/src/storage/users.json
@@ -110,5 +110,13 @@
     "role": "doctor",
     "createdAt": "2025-09-27T07:07:26.888Z",
     "updatedAt": "2025-09-27T07:07:26.888Z"
+  },
+  {
+    "id": "9c95ddce-f9de-4d24-87c5-a31d3d6d2a0f",
+    "firstName": "Armando",
+    "lastName": "Criscolo",
+    "role": "doctor",
+    "createdAt": "2025-09-27T13:16:01.786Z",
+    "updatedAt": "2025-09-27T13:16:01.786Z"
   }
 ]


### PR DESCRIPTION
# Description of Changes

## What has been done

* Implemented endpoint protection with authentication and role-based authorization.
* Refactored project structure to integrate middleware.
* Added invitation flow for doctors via email with token-based registration.

## Why it was done

* To secure API endpoints and ensure only authorized users can access them.
* To enable controlled onboarding of doctors through invite links.

## How to test

1. Send a POST request to `/doctors/invite` with a valid admin token and target email.
2. Check email inbox for invitation link.
3. Use the link to call `/auth/register/:token` with registration data in the request body.
4. Verify that the user is created and receives authentication tokens.

## Related issues

* Closes #25 

## Implementation details

* Added `authenticate` and `authorize` middlewares.
* Configured `nodemailer` with Gmail and App Passwords.
* Implemented token verification for invite-based registration.

## Limitations and known issues

* Cookie `secure: true` requires HTTPS; adjust for local testing.
* Error handling middleware should be improved for production readiness.

## Additional information

* Future: add email templates (HTML) and logging for failed invitations.
